### PR TITLE
Make getWeight method protected

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,8 @@
     "require": {
         "php": ">=5.4",
         "ext-bcmath": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~5.0"
     }
 }

--- a/src/Modulo11.php
+++ b/src/Modulo11.php
@@ -81,7 +81,7 @@ class Modulo11 implements Calculator
      * @param  int $start Start value for weight calculation (value of position 0)
      * @return int
      */
-    private function getWeight($pos, $start = 1)
+    protected function getWeight($pos, $start = 1)
     {
         $pos += $start;
         while ($pos > 10) {


### PR DESCRIPTION
Recently I've came across a check digit that was using mod 11 but the weights were being used in a different way. Instead of 1-10, they used 2-7. With the protected method, anyone can extend this method to support alternative mod11 based check digits.
