### PR TITLE
Add a .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/CHANGES.md export-ignore
+/CONTRIBUTING.md export-ignore
+/README.md export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Prevents test and unneeded files from being included in composer installs (via stable).
