### PR TITLE
Implement GTIN variant of Modulo10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Nothing...
+### Added
+- GTIN variant of `Modulo10` for validating barcodes like EAN, UPC, JAN, ITF and ISBN.
 
 ## [2.0.0] - 2017-12-05
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Implementations include:
 
  * [`Modulo10`](/src/Modulo10.php) and [`Luhn`](/src/Luhn.php) for modulo 10 check digits
    (Luhn is simply a shorthand for Modulo10).
+ * [`Modulo11`](/src/Modulo10Gtin.php) for modulo 10 check digits variant used in GTIN barcodes.
  * [`Modulo11`](/src/Modulo11.php) for modulo 11 check digits.
  * [`Modulo97`](/src/Modulo97.php) for modulo 97 check digits.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "byrokrat/checkdigit",
     "description": "Helper classes to calculate and validate ckecksums",
-    "keywords": ["modulo 10", "luhn", "modulo 11", "modulo 97","check digit"],
+    "keywords": ["modulo 10", "luhn", "modulo 11", "modulo 97","check digit","GTIN","EAN","UPC","ISBN"],
     "homepage": "https://github.com/byrokrat/checkdigit",
     "type": "library",
     "license": "Unlicense",

--- a/src/Modulo10Gtin.php
+++ b/src/Modulo10Gtin.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace byrokrat\checkdigit;
+
+/**
+ * Modulo10 calculator, variant used for GTIN (EAN, UPC, ISBN-13, JAN and ITF) barcodes
+ */
+class Modulo10Gtin implements Calculator
+{
+    /**
+     * Check if the last digit of number is a valid modulo 10 check digit
+     */
+    public function isValid(string $number): bool
+    {
+        return substr($number, -1) === $this->calculateCheckDigit(substr($number, 0, -1) ?: '');
+    }
+
+    /**
+     * Calculate the modulo 10 check digit for number
+     *
+     * @throws InvalidStructureException If $number is not numerical
+     */
+    public function calculateCheckDigit(string $number): string
+    {
+        if (!ctype_digit($number)) {
+            throw new InvalidStructureException(
+                "Number can only contain numerical characters, found <$number>"
+            );
+        }
+
+        $weight = 3;
+        $sum = 0;
+
+        foreach (array_reverse(str_split($number)) as $pos => $digit) {
+            $sum += $digit * ($pos % 2 ? 1 : $weight);
+        }
+
+        $ceil = $sum;
+
+        while ($ceil % 10 != 0) {
+            $ceil++;
+        }
+
+        return (string)($ceil-$sum);
+    }
+}

--- a/tests/Modulo10GtinTest.php
+++ b/tests/Modulo10GtinTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace byrokrat\checkdigit;
+
+class Modulo10GtinTest extends \PHPUnit\Framework\TestCase
+{
+    public function invalidStructureProvider()
+    {
+        return [
+            ['y'],
+            [''],
+            ['12.12']
+        ];
+    }
+
+    /**
+     * @dataProvider invalidStructureProvider
+     */
+    public function testInvalidStructureIsValid($number)
+    {
+        $this->expectException(InvalidStructureException::CLASS);
+        (new Modulo10Gtin)->isValid($number);
+    }
+
+    /**
+     * @dataProvider invalidStructureProvider
+     */
+    public function testInvalidStructureCalculateCheckDigit($number)
+    {
+        $this->expectException(InvalidStructureException::CLASS);
+        (new Modulo10Gtin)->calculateCheckDigit($number);
+    }
+
+    public function testIsValid()
+    {
+        $modulo10 = new Modulo10Gtin;
+        $this->assertTrue($modulo10->isValid('5701872203005'));//EAN-13
+        $this->assertTrue($modulo10->isValid('04210009'));//EAN-8
+        $this->assertTrue($modulo10->isValid('4902179014290'));//JAN-13
+        $this->assertTrue($modulo10->isValid('49012347'));//EAN-8
+        $this->assertTrue($modulo10->isValid('98765432109213'));//ITF-14
+        $this->assertTrue($modulo10->isValid('042100005264'));//UPC-A
+        $this->assertTrue($modulo10->isValid('9780596528126'));//IBAN-13
+        $this->assertFalse($modulo10->isValid('04252614'));//UPC-E (must first be expanded)
+        $this->assertFalse($modulo10->isValid('0596528132'));//IBAN-10 (Modulo11)
+    }
+
+    public function testCalculateCheckDigit()
+    {
+        $modulo10 = new Modulo10Gtin;
+        $this->assertSame('4', $modulo10->calculateCheckDigit('04210000526'));//Expaned UPC-8
+        $this->assertSame('6', $modulo10->calculateCheckDigit('978059652812'));//Converted IBAN-10
+    }
+}


### PR DESCRIPTION
The Modulo10 calculations for barcodes uses a weight of 3 instead of 2 (CreditCards). This class implements this variant.